### PR TITLE
7️⃣ feat(navbar, app & sign in): Agregar otro enrutamiento dependiendo si el usuario está o no signed in

### DIFF
--- a/src/Components/Navbar/index.jsx
+++ b/src/Components/Navbar/index.jsx
@@ -11,6 +11,13 @@ const Navbar = () => {
   const signOut = localStorage.getItem('sign-out')
   const parsedSignOut = JSON.parse(signOut)
   const isUserSignOut = context.signOut || parsedSignOut
+  // Account
+  const account = localStorage.getItem('account')
+  const parsedAccount = JSON.parse(account)
+  // Has an account
+  const noAccountInLocalStorage = parsedAccount ? Object.keys(parsedAccount).length === 0 : true
+  const noAccountInLocalState = context.account ? Object.keys(context.account).length === 0 : true
+  const hasUserAnAccount = !noAccountInLocalStorage || !noAccountInLocalState
 
   const handleSignOut = () => {
     const stringifiedSignOut = JSON.stringify(true)
@@ -19,18 +26,7 @@ const Navbar = () => {
   }
 
   const renderView = () => {
-    if (isUserSignOut) {
-      return (
-        <li>
-          <NavLink
-            to="/sign-in"
-            className={({ isActive }) => isActive ? activeStyle : undefined }
-            onClick={() => handleSignOut()}>
-            Sign out
-          </NavLink>
-        </li>
-      )
-    } else {
+    if (hasUserAnAccount && !isUserSignOut) {
       return (
         <>
           <li className='text-black/60'>
@@ -60,6 +56,17 @@ const Navbar = () => {
           </li>
         </>
       )
+    } else {
+      return (
+        <li>
+          <NavLink
+            to="/sign-in"
+            className={({ isActive }) => isActive ? activeStyle : undefined }
+            onClick={() => handleSignOut()}>
+            Sign in
+          </NavLink>
+        </li>
+      )
     }
   }
 
@@ -67,7 +74,7 @@ const Navbar = () => {
     <nav className='flex justify-between items-center fixed z-10 top-0 w-full py-5 px-8 text-sm font-light'>
       <ul className='flex items-center gap-3'>
         <li className='font-semibold text-lg'>
-          <NavLink to='/'>
+          <NavLink to={`${isUserSignOut ? '/sign-in' : '/'}`}>
             Shopi
           </NavLink>
         </li>

--- a/src/Pages/App/index.jsx
+++ b/src/Pages/App/index.jsx
@@ -1,5 +1,6 @@
-import { useRoutes, BrowserRouter } from 'react-router-dom'
-import { ShoppingCartProvider } from '../../Context'
+import { useContext } from 'react'
+import { useRoutes, BrowserRouter, Navigate } from 'react-router-dom'
+import { ShoppingCartProvider, initializeLocalStorage, ShoppingCartContext } from '../../Context'
 import Home from '../Home'
 import MyAccount from '../MyAccount'
 import MyOrder from '../MyOrder'
@@ -11,13 +12,26 @@ import CheckoutSideMenu from '../../Components/CheckoutSideMenu'
 import './App.css'
 
 const AppRoutes = () => {
+  const context = useContext(ShoppingCartContext)
+  // Account
+  const account = localStorage.getItem('account')
+  const parsedAccount = JSON.parse(account)
+  // Sign Out
+  const signOut = localStorage.getItem('sign-out')
+  const parsedSignOut = JSON.parse(signOut)
+  // Has an account
+  const noAccountInLocalStorage = parsedAccount ? Object.keys(parsedAccount).length === 0 : true
+  const noAccountInLocalState = Object.keys(context.account).length === 0
+  const hasUserAnAccount = !noAccountInLocalStorage || !noAccountInLocalState
+  const isUserSignOut = context.signOut || parsedSignOut
+
   let routes = useRoutes([
-    { path: '/', element: <Home /> },
-    { path: '/clothes', element: <Home /> },
-    { path: '/electronics', element: <Home /> },
-    { path: '/furnitures', element: <Home /> },
-    { path: '/toys', element: <Home /> },
-    { path: '/othes', element: <Home /> },
+    { path: '/', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
+    { path: '/clothes', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
+    { path: '/electronics', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
+    { path: '/furnitures', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
+    { path: '/toys', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
+    { path: '/others', element: hasUserAnAccount && !isUserSignOut ? <Home /> : <Navigate replace to={'/sign-in'} /> },
     { path: '/my-account', element: <MyAccount /> },
     { path: '/my-order', element: <MyOrder /> },
     { path: '/my-orders', element: <MyOrders /> },
@@ -31,6 +45,8 @@ const AppRoutes = () => {
 }
 
 const App = () => {
+  initializeLocalStorage()
+
   return (
     <ShoppingCartProvider>
       <BrowserRouter>

--- a/src/Pages/SignIn/index.jsx
+++ b/src/Pages/SignIn/index.jsx
@@ -54,6 +54,7 @@ function SignIn() {
           to="/">
           <button
             className='bg-black disabled:bg-black/40 text-white  w-full rounded-lg py-3 mt-4 mb-2'
+            onClick={() => handleSignIn()}
             disabled={!hasUserAnAccount}>
             Log in
           </button>


### PR DESCRIPTION
# Reto 7: Agregar otro enrutamiento dependiendo si el usuario está o no signed in

## 🥾 Step by step

1. Saber si el usuario tiene una cuenta en el componente de Navbar para mostrar o no los items
2. Si el usuario está sign-out, al darle click al logo debería llevarlo a `sign-in`
3. Modificar rutas para que no deje ver nada de la app a un usuario que no está `sign-in`

## 😎 Solución

### 1. Saber si el usuario tiene una cuenta en el componente de Navbar para mostrar o no los items

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 10 30 38 p m" src="https://user-images.githubusercontent.com/25943655/223911732-0efcaab2-3930-480e-b5ae-ab1f3a1628e1.png"></kbd>

### 2. Si el usuario está sign-out, al darle click al logo debería llevarlo a `sign-in`

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 10 33 13 p m" src="https://user-images.githubusercontent.com/25943655/223911586-3e017351-b833-46ed-833c-ff10ea7d3610.png"></kbd>

### 3. Modificar rutas para que no deje ver nada de la app a un usuario que no está `sign-in`

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 10 36 07 p m" src="https://user-images.githubusercontent.com/25943655/223911575-f1283f08-bb74-4cef-9ed4-d23b2d91852f.png"></kbd>

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 10 37 20 p m" src="https://user-images.githubusercontent.com/25943655/223911566-5352127d-4d52-4b7e-9ef7-268618fd43e1.png"></kbd>

### Videito final sobre cómo debería quedarte de genial:

https://user-images.githubusercontent.com/25943655/223911501-df3f0c95-5f76-45e6-8b55-dae634b5fd81.mov

Fin 🥲