### PR TITLE
🔟 feat(home): Agregar detallitos finales en Navbar y Card

### DIFF
--- a/src/Components/Card/index.jsx
+++ b/src/Components/Card/index.jsx
@@ -48,7 +48,7 @@ const Card = (data) => {
         <img className='w-full h-full object-cover rounded-lg' src={data.data.images[0]} alt={data.data.title} />
         {renderIcon(data.data.id)}
       </figure>
-      <p className='flex justify-between'>
+      <p className='flex justify-between items-center'>
         <span className='text-sm font-light'>{data.data.title}</span>
         <span className='text-lg font-medium'>${data.data.price}</span>
       </p>

--- a/src/Components/Navbar/index.jsx
+++ b/src/Components/Navbar/index.jsx
@@ -71,7 +71,7 @@ const Navbar = () => {
   }
 
   return (
-    <nav className='flex justify-between items-center fixed z-10 top-0 w-full py-5 px-8 text-sm font-light'>
+    <nav className='flex justify-between items-center fixed z-10 top-0 w-full py-5 px-8 text-sm font-light bg-white'>
       <ul className='flex items-center gap-3'>
         <li className='font-semibold text-lg'>
           <NavLink to={`${isUserSignOut ? '/sign-in' : '/'}`}>


### PR DESCRIPTION
# Reto 10: Agregar detallitos finales en Navbar y Card

## 🥾 Step by step

1. Agregar background white al Navbar para que no se vea transparente al hacer scroll en la página
2. Centrar el título y precio de la Card verticalmente

## 😎 Solución

### 1. Agregar background white al Navbar para que no se vea transparente al hacer scroll en la página

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 11 32 22 p m" src="https://user-images.githubusercontent.com/25943655/223918785-c35ecbaf-c264-43c5-a819-428d2c79f71e.png"></kbd>


### 2. Centrar el título y precio de la Card verticalmente

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 11 35 24 p m" src="https://user-images.githubusercontent.com/25943655/223918812-83f5ecbe-a415-4ab4-8d12-f5ce5d52206f.png"></kbd>

### Y listo !!! Así quedarían nuestros detallitos finales:

<kbd><img width="1439" alt="Captura de Pantalla 2023-03-08 a la(s) 11 37 56 p m" src="https://user-images.githubusercontent.com/25943655/223918978-0fa6dfef-639e-434a-a795-4ff2eb6a975b.png"></kbd>
